### PR TITLE
Fix quiz question count and start numbering

### DIFF
--- a/src/contexts/QuizContext.tsx
+++ b/src/contexts/QuizContext.tsx
@@ -18,65 +18,67 @@ type QuizAction =
   | { type: 'GOTO_QUESTION'; payload: number };
 
 const initialState: QuizState = {
-  currentQuestionIndex: 0,
+  currentQuestionIndex: -1,
   answers: [],
   results: null,
   isComplete: false,
 };
 
 function quizReducer(state: QuizState, action: QuizAction): QuizState {
-  switch (action.type) {
-    case 'ANSWER_QUESTION':
-      const existingAnswerIndex = state.answers.findIndex(
-        a => a.questionId === action.payload.questionId
-      );
-      
-      let newAnswers;
-      if (existingAnswerIndex >= 0) {
-        newAnswers = [...state.answers];
-        newAnswers[existingAnswerIndex] = action.payload;
-      } else {
-        newAnswers = [...state.answers, action.payload];
+    switch (action.type) {
+      case 'ANSWER_QUESTION': {
+        const existingAnswerIndex = state.answers.findIndex(
+          a => a.questionId === action.payload.questionId
+        );
+
+        let newAnswers;
+        if (existingAnswerIndex >= 0) {
+          newAnswers = [...state.answers];
+          newAnswers[existingAnswerIndex] = action.payload;
+        } else {
+          newAnswers = [...state.answers, action.payload];
+        }
+
+        return {
+          ...state,
+          answers: newAnswers,
+        };
       }
-      
-      return {
-        ...state,
-        answers: newAnswers,
-      };
-      
-    case 'NEXT_QUESTION':
-      return {
-        ...state,
-        currentQuestionIndex: state.currentQuestionIndex + 1,
-      };
-      
-    case 'PREVIOUS_QUESTION':
-      return {
-        ...state,
-        currentQuestionIndex: Math.max(0, state.currentQuestionIndex - 1),
-      };
-      
-    case 'COMPLETE_QUIZ':
-      const results = calculateQuizResults(state.answers);
-      return {
-        ...state,
-        results,
-        isComplete: true,
-      };
-      
-    case 'RESET_QUIZ':
-      return initialState;
-      
-    case 'GOTO_QUESTION':
-      return {
-        ...state,
-        currentQuestionIndex: action.payload,
-      };
-      
-    default:
-      return state;
+
+      case 'NEXT_QUESTION':
+        return {
+          ...state,
+          currentQuestionIndex: state.currentQuestionIndex + 1,
+        };
+
+      case 'PREVIOUS_QUESTION':
+        return {
+          ...state,
+          currentQuestionIndex: Math.max(0, state.currentQuestionIndex - 1),
+        };
+
+      case 'COMPLETE_QUIZ': {
+        const results = calculateQuizResults(state.answers);
+        return {
+          ...state,
+          results,
+          isComplete: true,
+        };
+      }
+
+      case 'RESET_QUIZ':
+        return initialState;
+
+      case 'GOTO_QUESTION':
+        return {
+          ...state,
+          currentQuestionIndex: action.payload,
+        };
+
+      default:
+        return state;
+    }
   }
-}
 
 interface QuizContextType {
   state: QuizState;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -13,7 +13,7 @@ function QuizContent() {
     return <QuizResults />;
   }
 
-  if (state.currentQuestionIndex === 0 && state.answers.length === 0) {
+  if (state.currentQuestionIndex === -1) {
     return <QuizLanding />;
   }
 

--- a/src/pages/LearnMore.tsx
+++ b/src/pages/LearnMore.tsx
@@ -228,7 +228,7 @@ const LearnMore = () => {
                     <p className="text-sm text-muted-foreground">Top Recommendations</p>
                   </Card>
                   <Card className="p-4 text-center">
-                    <div className="text-2xl font-bold text-primary mb-1">24</div>
+                    <div className="text-2xl font-bold text-primary mb-1">22</div>
                     <p className="text-sm text-muted-foreground">Assessment Questions</p>
                   </Card>
                 </div>
@@ -318,7 +318,7 @@ const LearnMore = () => {
                 <h4 className="font-semibold mb-2">How long does it take to complete?</h4>
                 <p className="text-muted-foreground">
                   The assessment typically takes 10-15 minutes to complete. We've designed it to be 
-                  comprehensive yet respectful of your time, with 24 carefully selected questions 
+                  comprehensive yet respectful of your time, with 22 carefully selected questions
                   that maximize insight while minimizing assessment fatigue.
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- Correct learn-more copy to reflect the 22 quiz questions
- Begin quiz at the first question so progress starts at 1 of 22

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 12 problems; includes errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a6304dab448320ae71368aa9baa2f7